### PR TITLE
crc32c 2.7.1 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ test:
 about:
   home: https://github.com/ICRAR/crc32c
   summary: A python package implementing the crc32c algorithm in hardware and software
-  license: LGPL-2.0
+  license: LGPL-2.1-or-later
   license_family: LGPL
   license_file: LICENSE
   summary: A python package exposing the Intel SSE4.2 CRC32C instruction

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,8 @@ requirements:
   host:
     - pip
     - python
+    - wheel
+    - setuptools
   run:
     - python
 
@@ -49,6 +51,8 @@ about:
     It automatically chooses between a hardware-based implementation
     (using the CRC32C SSE 4.2 instruction of Intel CPUs, and the crc32* instructions on ARMv8 CPUs), 
     or a software-based one when no hardware support can be found.
+  doc_url: https://github.com/ICRAR/crc32c/blob/master/README.rst
+  dev_url: https://github.com/ICRAR/crc32c
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ test:
 about:
   home: https://github.com/ICRAR/crc32c
   summary: A python package implementing the crc32c algorithm in hardware and software
-  license: GNU Lesser General Public v2 or later (LGPLv2+)
+  license: LGPL-2.0
   license_family: LGPL
   license_file: LICENSE
   summary: A python package exposing the Intel SSE4.2 CRC32C instruction

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "crc32c" %}
-{% set version = "2.3.post0" %}
+{% set version = "2.7.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,16 +7,16 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 7d4b39ca6791830c4f1c053d2d8983627af702f0445535ff53d3220f35cf6ce6
+  sha256: f91b144a21eef834d64178e01982bb9179c354b3e9e5f4c803b0e5096384968c
+  skip: True  # [py<37]
 
 build:
   number: 0
-  script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv '
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:
     - {{ compiler('c') }}
-
   host:
     - pip
     - python
@@ -24,16 +24,31 @@ requirements:
     - python
 
 test:
+  source_files:
+    - test
+    - pytest.ini
+    - run-tests.py
   imports:
     - crc32c
-
+  commands:
+    - pip check
+    - python -m run-tests
+  requires:
+    - pip
+    - pytest
 
 about:
   home: https://github.com/ICRAR/crc32c
+  summary: A python package implementing the crc32c algorithm in hardware and software
   license: GNU Lesser General Public v2 or later (LGPLv2+)
   license_family: LGPL
   license_file: LICENSE
   summary: A python package exposing the Intel SSE4.2 CRC32C instruction
+  description: | 
+    This package implements the crc32c checksum algorithm.
+    It automatically chooses between a hardware-based implementation
+    (using the CRC32C SSE 4.2 instruction of Intel CPUs, and the crc32* instructions on ARMv8 CPUs), 
+    or a software-based one when no hardware support can be found.
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
crc32c 2.7.1 

**Destination channel:** Default

### Links

- [PKG-7349]
- dev_url:        https://github.com/ICRAR/crc32c/tree/v2.7.1
- conda_forge:    https://github.com/conda-forge/crc32c-feedstock
- pypi:           https://pypi.org/project/crc32c/2.7.1
- pypi inspector: https://inspector.pypi.io/project/crc32c/2.7.1

### Explanation of changes:

- new version number


[PKG-7349]: https://anaconda.atlassian.net/browse/PKG-7349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ